### PR TITLE
Improved Meteor image decoding

### DIFF
--- a/bin/gen-static-page.sh
+++ b/bin/gen-static-page.sh
@@ -109,18 +109,25 @@ echo "</ul>" >> $dirList
 
 
 function gallery_meteor {
-
-howManyToday=$(ls $meteorDir/img/$(date +"%Y/%m/%d")/*-Ch0.jpg 2> /dev/null| wc -l)
+  local howManyToday meteorLastDir meteorLastLog indexFile lastDateTime lastDate lastTime
+howManyToday=$(ls $meteorDir/img/$(date +"%Y/%m/%d")/*.th.jpg 2> /dev/null | wc -l)
 meteorLastDir=$(dirname $(cat $wwwDir/meteor-last-recording.tmp))
 
+# Get last file name (contains date and time).
+meteorLastLog=$(basename $(cat $wwwDir/meteor-last-recording.tmp))
 
 echo "<h2>METEOR-M2 recordings</h2>" >> $dirList
 echo "<h4>Recent pass</h4>" >> $dirList
+if [ $meteorLastLog ];
+then
+  # Get date and time
+  lastDateTime=$(echo $meteorLastLog | cut -d "_" -f 1)
+  lastDate=$(echo $lastDateTime | cut -d "-" -f 1)
+  lastTime=$(echo $lastDateTime | cut -d "-" -f 2)
+  echo "<h6>($lastDate , $lastTime)</h6>" >> $dirList
+fi
 echo "<a href='$meteorLastDir/index.html'>" >> $dirList
-echo "<img src='$(cat $wwwDir/meteor-last-recording.tmp)-Ch0.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "<img src='$(cat $wwwDir/meteor-last-recording.tmp)-Ch1.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "<img src='$(cat $wwwDir/meteor-last-recording.tmp)-Ch2.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "<img src='$(cat $wwwDir/meteor-last-recording.tmp)-Combo.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
+echo "<img src='$(cat $wwwDir/meteor-last-recording.tmp).th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
 echo "</a>" >> $dirList
 
 echo "<p></p>" >> $dirList
@@ -137,8 +144,13 @@ do
     echo "<li>($m)" >> $dirList
     for d in $(ls $meteorDir/img/$y/$m/ | sort -n)
     do
-      # collect info about files in the directory
-      echo "<a href='${wwwRootPath}/recordings/meteor/img/$y/$m/$d/index.html'>$d</a> " >> $dirList
+      indexFile="recordings/meteor/img/$y/$m/$d/index.html"
+      # Only add a link to the index file if there is an index file.
+      if [[ -f "${wwwDir}/${indexFile}" ]];
+      then
+        # collect info about files in the directory
+        echo "<a href='${wwwRootPath}/${indexFile}'>$d</a> " >> $dirList
+      fi
     done
     echo "</li>" >> $dirList
   done

--- a/bin/gen-static-page.sh
+++ b/bin/gen-static-page.sh
@@ -41,12 +41,16 @@ lastkepsU=$(cat "$wwwDir/kepsU.tmp")
 
 keplerDays=$(echo "(($(date +"%s") - $lastkepsU ) / (60*60*24))" | bc )
 echo $keplerDays
-if [ $keplerDays -le 7 ]; then keplerInfo="<span class='badge badge-pill badge-success'>OK</span>"
-else keplerInfo="<span class='badge badge-pill badge-danger'>outdated</span>"; fi
+if [ $keplerDays -le 7 ]; 
+then
+  keplerInfo="<span class='badge badge-pill badge-success'>OK</span>"
+else
+  keplerInfo="<span class='badge badge-pill badge-danger'>outdated</span>"
+fi
 
 echo "lastkeps: $lastkeps"
 
-keplerInfo="Keplers updated: $lastkeps ($keplerDays days old) $keplerInfo<br />"
+keplerInfo="Keplers last updated: $lastkeps ($keplerDays days old) $keplerInfo<br />"
 
 ##### autowx2 uptime ########
 
@@ -63,101 +67,138 @@ autowxUptime="autowx2 uptime: $autowxUptimeH h (~$autowxUptimeD d)<br />"
 
 shortlistofnextpassess="<br/>Next passes: $(cat "$wwwDir/nextpassshort.tmp")<br />"
 
+function echoSetValueFor {
+  echo "Please set an appropriate value for ${1}."
+}
+
+function generateGallery {
+  local loopVar satelliteDirectory lastRecordingFile sectionTitle howManyToday
+  local lastDir lastLog indexFile lastDateTime lastDate lastTime imagesHtml
+
+  for loopVar in "$@";
+  do
+    # Parameters need to come in the format [--NAME=VALUE], so that it becomes
+    # more readable.
+    local parameterName parameterValue
+    parameterName=$(echo ${loopVar} | cut -d "=" -f 1)
+    parameterValue=$(echo ${loopVar} | cut -d "=" -f 2-)
+
+    case "${parameterName}" in
+      "--satDir")
+        satelliteDirectory=$parameterValue
+        ;;
+
+      "--lastRecFile")
+        lastRecordingFile=$parameterValue
+        ;;
+        
+      "--title")
+        sectionTitle=$parameterValue
+        ;;
+
+      "--imagesHtml")
+        imagesHtml=$parameterValue
+        ;;
+
+      *)
+        echo "Invalid parameter option: ${parameterName}"
+        ;;
+    esac
+  done
+
+  # Make sure there are values for each parameter.
+  if [[ "${satelliteDirectory}" == "" || ! -d $satelliteDirectory ]];
+  then
+    echo "Invalid satellite directory: ${satelliteDirectory}"
+    echoSetValueFor "--satDir"
+  elif [ "${sectionTitle}" == "" ];
+  then
+    echo "Invalid section title: ${sectionTitle}"
+    echoSetValueFor "--title"
+  elif [[ "${lastRecordingFile}" == "" || ! -f $wwwDir/$lastRecordingFile ]];
+  then
+    echo "Invalid last recording file: ${lastRecordingFile}"
+    echo "Full path tried: ${wwwDir}/${lastRecordingFile}"
+    echoSetValueFor "--lastRecFile"
+  elif [ "${imagesHtml}" == "" ];
+  then
+    echo "Invalid images list: ${imagesHtml}"
+    echoSetValueFor "--imagesHtml"
+  fi
+
+  #  Start generating HTML file
+  
+  howManyToday=$(ls $satelliteDirectory/img/$(date +"%Y/%m/%d")/*.log 2> /dev/null| wc -l)
+  lastDir=$(dirname $(cat $wwwDir/$lastRecordingFile))
+  lastLog=$(basename $(cat $wwwDir/$lastRecordingFile))
+
+  # Generate title
+  echo "<h2>${sectionTitle}</h2>" >> $dirList
+  echo "<h4>Recent pass</h4>" >> $dirList
+  if [ $lastLog ];
+  then
+    # Get date and time of last recording
+    lastDateTime=$(echo $lastLog | cut -d "_" -f 1)
+    lastDate=$(echo $lastDateTime | cut -d "-" -f 1)
+    lastTime=$(echo $lastDateTime | cut -d "-" -f 2)
+    echo "<h6>($lastDate , $lastTime)</h6>" >> $dirList
+  fi
+  
+  # Generate images
+  echo "<a href='$lastDir/index.html'>" >> $dirList
+  echo "${imagesHtml}" >> $dirList
+  echo "</a>" >> $dirList
+  echo "<p></p>" >> $dirList
+
+  # Generate archive
+  echo "<h4>Archive</h4>" >> $dirList
+  echo "<ul>" >> $dirList
+  echo "<li><a href='${wwwRootPath}/${satelliteDirectory}/img/$(date +"%Y/%m/%d")/index.html'>Today</a>" >> $dirList
+  echo "<span class='badge badge-pill badge-light'>$howManyToday</span> </li>" >> $dirList
+
+  for y in $(ls $satelliteDirectory/img/ | sort -n)
+  do
+    echo "<li>$y<ul>" >> $dirList
+    for m in $(ls $satelliteDirectory/img/$y | sort -n)
+    do
+      echo "<li>($m)" >> $dirList
+      for d in $(ls $satelliteDirectory/img/$y/$m/ | sort -n)
+      do
+        indexFile="${satelliteDirectory}/img/$y/$m/$d/index.html"
+        # Only add a link to the index file if there is an index file.
+        if [[ -f "${indexFile}" ]];
+        then
+          # collect info about files in the directory
+          echo "<a href='${wwwRootPath}/${indexFile}'>$d</a> " >> $dirList
+        fi
+      done
+      echo "</li>" >> $dirList
+    done
+    echo "</ul></li>" >> $dirList
+  done
+  echo "</ul>" >> $dirList
+}
 
 # ---- NOAA list all dates and times  -------------------------------------------------#
 
 function gallery_noaa {
-
-howManyToday=$(ls $noaaDir/img/$(date +"%Y/%m/%d")/*.log 2> /dev/null| wc -l)
-
-noaaLastDir=$(dirname $(cat $wwwDir/noaa-last-recording.tmp))
-
-echo "<h2>NOAA recordings</h2>" >> $dirList
-echo "<h4>Recent pass</h4>" >> $dirList
-echo "<a href='$noaaLastDir/index.html'>" >> $dirList
-echo "<img src='$(cat $wwwDir/noaa-last-recording.tmp)-therm+map.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "<img src='$(cat $wwwDir/noaa-last-recording.tmp)-MCIR-precip+map.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "<img src='$(cat $wwwDir/noaa-last-recording.tmp)-HVC+map.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "<img src='$(cat $wwwDir/noaa-last-recording.tmp)-NO+map.th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "</a>" >> $dirList
-echo "<p></p>" >> $dirList
-
-echo "<h4>Archive</h4>" >> $dirList
-echo "<ul>" >> $dirList
-echo "<li><a href='${wwwRootPath}/recordings/noaa/img/$(date +"%Y/%m/%d")/index.html'>Today</a> <span class='badge badge-pill badge-light'>$howManyToday</span> </li>" >> $dirList
-
-for y in $(ls $noaaDir/img/ | sort -n)
-do
-  echo "<li>$y<ul>" >> $dirList
-  for m in $(ls $noaaDir/img/$y | sort -n)
-  do
-    echo "<li>($m)" >> $dirList
-    for d in $(ls $noaaDir/img/$y/$m/ | sort -n)
-    do
-      # collect info about files in the directory
-      echo "<a href='${wwwRootPath}/recordings/noaa/img/$y/$m/$d/index.html'>$d</a> " >> $dirList
-    done
-    echo "</li>" >> $dirList
-  done
-  echo "</ul></li>" >> $dirList
-done
-echo "</ul>" >> $dirList
-
+  local images lastRecFile
+  lastRecFile="noaa-last-recording.tmp"
+  images="<img src='$(cat $wwwDir/${lastRecFile})-therm+map.th.jpg' alt='recent recording' class='img-thumbnail' />"
+  images="${images} <img src='$(cat $wwwDir/${lastRecFile})-MCIR-precip+map.th.jpg' alt='recent recording' class='img-thumbnail' />"
+  images="${images} <img src='$(cat $wwwDir/${lastRecFile})-HVC+map.th.jpg' alt='recent recording' class='img-thumbnail' />"
+  images="${images} <img src='$(cat $wwwDir/${lastRecFile})-NO+map.th.jpg' alt='recent recording' class='img-thumbnail' />"
+  generateGallery --satDir=$noaaDir --title="NOAA Recordings" --lastRecFile="${lastRecFile}" --imagesHtml="${images}"
 } # end function gallery noaa
 
 # ---- METEOR list all dates and times  -------------------------------------------------#
 
 
 function gallery_meteor {
-  local howManyToday meteorLastDir meteorLastLog indexFile lastDateTime lastDate lastTime
-howManyToday=$(ls $meteorDir/img/$(date +"%Y/%m/%d")/*.th.jpg 2> /dev/null | wc -l)
-meteorLastDir=$(dirname $(cat $wwwDir/meteor-last-recording.tmp))
-
-# Get last file name (contains date and time).
-meteorLastLog=$(basename $(cat $wwwDir/meteor-last-recording.tmp))
-
-echo "<h2>METEOR-M2 recordings</h2>" >> $dirList
-echo "<h4>Recent pass</h4>" >> $dirList
-if [ $meteorLastLog ];
-then
-  # Get date and time
-  lastDateTime=$(echo $meteorLastLog | cut -d "_" -f 1)
-  lastDate=$(echo $lastDateTime | cut -d "-" -f 1)
-  lastTime=$(echo $lastDateTime | cut -d "-" -f 2)
-  echo "<h6>($lastDate , $lastTime)</h6>" >> $dirList
-fi
-echo "<a href='$meteorLastDir/index.html'>" >> $dirList
-echo "<img src='$(cat $wwwDir/meteor-last-recording.tmp).th.jpg' alt='recent recording' class='img-thumbnail' />" >> $dirList
-echo "</a>" >> $dirList
-
-echo "<p></p>" >> $dirList
-
-echo "<h4>Archive</h4>" >> $dirList
-echo "<ul>" >> $dirList
-echo "<li><a href='${wwwRootPath}/recordings/meteor/img/$(date +"%Y/%m/%d")/index.html'>Today</a> <span class='badge badge-pill badge-light'>$howManyToday</span> </li>" >> $dirList
-
-for y in $(ls $meteorDir/img/ | grep -v 'raw' | sort -n)
-do
-  echo "<li>$y<ul>" >> $dirList
-  for m in $(ls $meteorDir/img/$y | sort -n)
-  do
-    echo "<li>($m)" >> $dirList
-    for d in $(ls $meteorDir/img/$y/$m/ | sort -n)
-    do
-      indexFile="recordings/meteor/img/$y/$m/$d/index.html"
-      # Only add a link to the index file if there is an index file.
-      if [[ -f "${wwwDir}/${indexFile}" ]];
-      then
-        # collect info about files in the directory
-        echo "<a href='${wwwRootPath}/${indexFile}'>$d</a> " >> $dirList
-      fi
-    done
-    echo "</li>" >> $dirList
-  done
-  echo "</ul></li>" >> $dirList
-done
-echo "</ul>" >> $dirList
-
+  local images lastRecFile
+  lastRecFile="meteor-last-recording.tmp"
+  images="<img src='$(cat $wwwDir/${lastRecFile}).th.jpg' alt='recent recording' class='img-thumbnail' />"
+  generateGallery --satDir=$meteorDir --title="METEOR-M2 Recordings" --lastRecFile="${lastRecFile}" --imagesHtml="${images}"
 } # end function gallery meteor
 
 

--- a/modules/meteor-m2/meteor.conf.example
+++ b/modules/meteor-m2/meteor.conf.example
@@ -5,14 +5,28 @@
 # where images from mrlpt are saved
 # (as declared in mlrptrc config file - check it!)
 # eg: /var/lrpt/images/
-rawImageDir="/meteor/img/raw/"
+rawImageDir="/home/pi/mlrpt/images/"
 
+medetExec="$baseDir/medet/medet_arm"
 
 # directory with meteor stuff
-meteorDir="$recordingDir/meteor/"
+meteorDir="$recordingDir/meteor"
+
+# directory of meteor recordings
+rootMeteorRecDir="$meteorDir/rec"
+recdir="$rootMeteorRecDir/"$(date +"%Y/%m/%d")
 
 # directory where the images finally will go
-imgdir="$meteorDir/img/"$(date +"%Y/%m/%d/")
+rootMeteorImgDir="$meteorDir/img"
+imgdir="$rootMeteorImgDir/"$(date +"%Y/%m/%d")
+
+# Option to save images as PNG or JPG (if neither, defaults to JPG)
+imageExtension="png"
+# imageExtension="jpg"
 
 # resize images to the given size to avoid growing of the repository; in px
 resizeimageto=1024
+
+# Shall we remove the audio and processing files? If not, comment out below
+# or leave blank.
+removeFiles="true"

--- a/modules/meteor-m2/meteor.sh
+++ b/modules/meteor-m2/meteor.sh
@@ -59,10 +59,10 @@ echo "freq=$freq"
 # recording sumbodule
 #
 
-source $scriptDir/meteor_record.sh
+source $scriptDir/meteor_record.sh $satellite $freq $fileNameCore "" "" $duration $peak
 
 #
 # meteor gallery
 #
 
-source $scriptDir/meteor_gallery.sh
+source $scriptDir/meteor_gallery.sh 

--- a/modules/meteor-m2/meteor.sh
+++ b/modules/meteor-m2/meteor.sh
@@ -56,10 +56,16 @@ echo "freq=$freq"
 
 
 #
-# recording sumbodule
+# recording submodule
 #
 
 source $scriptDir/meteor_record.sh $satellite $freq $fileNameCore "" "" $duration $peak
+
+#
+# Processing
+#
+
+source $scriptDir/meteor_process.sh $fileNameCore
 
 #
 # meteor gallery

--- a/modules/meteor-m2/meteor.sh
+++ b/modules/meteor-m2/meteor.sh
@@ -8,6 +8,7 @@
 scriptDir="$(dirname "$(realpath "$0")")"
 source $scriptDir/basedir_conf.py
 source $baseDir/_listvars.sh
+source $baseDir/shell_functions.sh
 
 # read module config
 

--- a/modules/meteor-m2/meteor.sh
+++ b/modules/meteor-m2/meteor.sh
@@ -73,3 +73,9 @@ source $scriptDir/meteor_process.sh $fileNameCore
 #
 
 source $scriptDir/meteor_gallery.sh 
+
+#
+# generate static main page(s)
+#
+
+source $baseDir/bin/gen-static-page.sh

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -19,6 +19,8 @@ htmlTemplate="$wwwDir/index.tpl"
 
 makethumb() {
     picture="$1"
+    # Thumbnail can be in JPG, as we're not interested in super high quality for
+    # the thumbnail image. The actual image is more important.
     local thumbnail=$(basename "$picture" .$imageExtension)".th.jpg"
     convert -define jpeg:size=200x200 "$picture" -thumbnail '200x200^' granite: +swap -gravity center -extent 200x200 -composite -quality 82 "$thumbnail"
     echo "$thumbnail"
@@ -37,7 +39,7 @@ varFreq=$(sed '7q;d' $logFile)
 
 dateTime=$(date -d @$varStart +"%Y-%m-%d")
 dateTimeDir=$(date -d @$varStart +"%Y/%m/%d")  # directory format of date, eg. 2018/11/22/
-wwwPath=$imgdir/$dateTimeDir
+wwwPath=$rootMeteorImgDir/$dateTimeDir
 
 
 

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -75,7 +75,13 @@ else
       # generate thumbnail
       thumbnail=$(makethumb "$image")
   		echo $thumbnail
-      echo "<a data-fancybox='gallery' data-caption='$varSat | $varDate ($sizeof)' href='$wwwPath/$image'><img src='$wwwPath/$thumbnail' alt='meteor image' title='$sizeof' class='img-thumbnail' /></a> " >> $outHtml
+
+      # If the base name is the same as the core filename, then we can add it.
+      # Otherwise, we'd be adding a thumbnail that isn't part of this recording.
+      if [ $base == $fileNameCore ];
+      then
+        echo "<a data-fancybox='gallery' data-caption='$varSat | $varDate ($sizeof)' href='$wwwPath/$image'><img src='$wwwPath/$thumbnail' alt='meteor image' title='$sizeof' class='img-thumbnail' /></a> " >> $outHtml
+      fi
     fi
   done
 

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -47,6 +47,7 @@ wwwPath="/recordings/meteor/img/${dateTimeDir}"
 # -----------------------------------------------------------------------------#
 
 
+
 cd "./var/www${wwwPath}"
 
 if [ $(ls *.$imageExtension 2> /dev/null | wc -l) = 0 ];
@@ -89,11 +90,11 @@ else
   #
   # get image core name
   #
-  # From the full file name, get the head (?). From the file name:
-  # 1. Split the string on the underscore character ('_'), and retain the 2nd item.
-  # 2. Split that string on the period character ('.'), and retain the 1st item.
-  meteorcorename=$(ls *.$imageExtension | head -1 | cut -d "_" -f 2 | cut -d "." -f 1)
-  echo $wwwPath/$meteorcorename > $wwwDir/meteor-last-recording.tmp
+  # From the list of files, get the first file. From the file name, split that
+  # string on the period character ('.'), and retain the 1st item (remove all
+  # extensions).
+  meteorcorename=$(ls *.$imageExtension | head -1 | cut -d "." -f 1)
+  echo $wwwPath/$fileNameCore > $wwwDir/meteor-last-recording.tmp
 
 
   # ----consolidate data from the given day ------------------------------------#

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -104,12 +104,4 @@ else
   htmlBody=$(cat $indexHtml.tmp)
 
   source $htmlTemplate > $indexHtml
-
-  #
-  # generate static main page(s)
-  #
-
-  $baseDir/bin/gen-static-page.sh
-
-
 fi # there are images

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -66,13 +66,17 @@ else
   #
   for image in *.$imageExtension
   do
+    # Create thumbnail image if it doesn't already exist
+    base=$(basename $image .$imageExtension | cut -d "." -f 1)
+    if [ ! -f "${base}.th.jpg" ];
+    then
   		echo "Thumb for $image"
-  		base=$(basename $image .$imageExtension)
       sizeof=$(du -sh "$image" | cut -f 1)
       # generate thumbnail
       thumbnail=$(makethumb "$image")
   		echo $thumbnail
       echo "<a data-fancybox='gallery' data-caption='$varSat | $varDate ($sizeof)' href='$wwwPath/$image'><img src='$wwwPath/$thumbnail' alt='meteor image' title='$sizeof' class='img-thumbnail' /></a> " >> $outHtml
+    fi
   done
 
 

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -39,7 +39,7 @@ varFreq=$(sed '7q;d' $logFile)
 
 dateTime=$(date -d @$varStart +"%Y-%m-%d")
 dateTimeDir=$(date -d @$varStart +"%Y/%m/%d")  # directory format of date, eg. 2018/11/22/
-wwwPath=$rootMeteorImgDir/$dateTimeDir
+wwwPath="/recordings/meteor/img/${dateTimeDir}"
 
 
 
@@ -47,7 +47,7 @@ wwwPath=$rootMeteorImgDir/$dateTimeDir
 # -----------------------------------------------------------------------------#
 
 
-cd $wwwPath
+cd "./var/www${wwwPath}"
 
 if [ $(ls *.$imageExtension 2> /dev/null | wc -l) = 0 ];
 then
@@ -79,8 +79,10 @@ else
   #
   # get image core name
   #
-
-  meteorcorename=$(ls *.$imageExtension | head -1 | cut -d "-" -f 1-2)
+  # From the full file name, get the head (?). From the file name:
+  # 1. Split the string on the underscore character ('_'), and retain the 2nd item.
+  # 2. Split that string on the period character ('.'), and retain the 1st item.
+  meteorcorename=$(ls *.$imageExtension | head -1 | cut -d "_" -f 2 | cut -d "." -f 1)
   echo $wwwPath/$meteorcorename > $wwwDir/meteor-last-recording.tmp
 
 

--- a/modules/meteor-m2/meteor_gallery.sh
+++ b/modules/meteor-m2/meteor_gallery.sh
@@ -18,9 +18,9 @@ htmlTemplate="$wwwDir/index.tpl"
 # ---single gallery preparation------------------------------------------------#
 
 makethumb() {
-    obrazek="$1"
-    local thumbnail=$(basename "$obrazek" .jpg)".th.jpg"
-    convert -define jpeg:size=200x200 "$obrazek" -thumbnail '200x200^' granite: +swap -gravity center -extent 200x200 -composite -quality 82 "$thumbnail"
+    picture="$1"
+    local thumbnail=$(basename "$picture" .$imageExtension)".th.jpg"
+    convert -define jpeg:size=200x200 "$picture" -thumbnail '200x200^' granite: +swap -gravity center -extent 200x200 -composite -quality 82 "$thumbnail"
     echo "$thumbnail"
     }
 
@@ -37,7 +37,7 @@ varFreq=$(sed '7q;d' $logFile)
 
 dateTime=$(date -d @$varStart +"%Y-%m-%d")
 dateTimeDir=$(date -d @$varStart +"%Y/%m/%d")  # directory format of date, eg. 2018/11/22/
-wwwPath=$wwwRootPath/recordings/meteor/img/$dateTimeDir
+wwwPath=$imgdir/$dateTimeDir
 
 
 
@@ -45,21 +45,12 @@ wwwPath=$wwwRootPath/recordings/meteor/img/$dateTimeDir
 # -----------------------------------------------------------------------------#
 
 
-cd $rawImageDir
+cd $wwwPath
 
-if [ $(ls *.jpg 2> /dev/null | wc -l) = 0 ];
+if [ $(ls *.$imageExtension 2> /dev/null | wc -l) = 0 ];
 then
-  echo "no images";
+  echo "No images found to add to gallery";
 else
-
-  #
-  # should we resize images?
-  #
-
-  if [ "$resizeimageto" != "" ]; then
-    echo "Resizing images to $resizeimageto px"
-    mogrify -resize ${resizeimageto}x${resizeimageto}\> *.jpg
-  fi
 
   #
   # some headers
@@ -71,18 +62,15 @@ else
   #
   # loop over images and generate thumbnails
   #
-
-
-
-  for obrazek in *.jpg
+  for image in *.$imageExtension
   do
-  		echo "Thumb for $obrazek"
-  		base=$(basename $obrazek .jpg)
-      sizeof=$(du -sh "$obrazek" | cut -f 1)
+  		echo "Thumb for $image"
+  		base=$(basename $image .$imageExtension)
+      sizeof=$(du -sh "$image" | cut -f 1)
       # generate thumbnail
-      thumbnail=$(makethumb "$obrazek")
+      thumbnail=$(makethumb "$image")
   		echo $thumbnail
-      echo "<a data-fancybox='gallery' data-caption='$varSat | $varDate ($sizeof)' href='$wwwPath/$obrazek'><img src='$wwwPath/$thumbnail' alt='meteor image' title='$sizeof' class='img-thumbnail' /></a> " >> $outHtml
+      echo "<a data-fancybox='gallery' data-caption='$varSat | $varDate ($sizeof)' href='$wwwPath/$image'><img src='$wwwPath/$thumbnail' alt='meteor image' title='$sizeof' class='img-thumbnail' /></a> " >> $outHtml
   done
 
 
@@ -90,15 +78,8 @@ else
   # get image core name
   #
 
-  meteorcorename=$(ls *.jpg | head -1 | cut -d "-" -f 1-2)
+  meteorcorename=$(ls *.$imageExtension | head -1 | cut -d "-" -f 1-2)
   echo $wwwPath/$meteorcorename > $wwwDir/meteor-last-recording.tmp
-
-  #
-  # move images to their destination
-  #
-
-  mv $rawImageDir/* $imgdir/
-  # cp $rawImageDir/* $imgdir/
 
 
   # ----consolidate data from the given day ------------------------------------#

--- a/modules/meteor-m2/meteor_process.sh
+++ b/modules/meteor-m2/meteor_process.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+
+processedFile="${recdir}/${3}"
+imageFile="${imgdir}/${3}"
+normalisedAudioFile="${processedFile}.wav"
+demodulatedAudioFile="${processedFile}.qpsk"
+decodedAudioFile="${processedFile}.dec"
+
+
+# Demodulate the audio file
+echo "Demodulation in progress (QPSK)"
+meteor_demod -B -o $demodulatedAudioFile $normalisedAudioFile
+
+# Decode th demoodulated file
+echo "Decoding in progress (QPSK to BMP)"
+./medet/medet_arm $demodulatedAudioFile $processedFile -cd
+
+# Get the image file extension
+if [ "$imageExtension" == "" ]; then
+  imageExtension = "jpg"
+fi
+
+# Should we resize the image?
+if [ "$resizeimageto" != "" ]; then
+  echo "Resizing image to $resizeimageto px"
+  resizeSwitch="-resize ${resizeimageto}x${resizeimageto}>"
+fi
+
+# Decide the file and make image.
+if [ -f $decodedAudioFile ]; then
+    echo "I got a successful ${3}.dec file. Creating false color image"
+    ./medet/medet_arm $decodedAudioFile "${iageFile}-122" -r 66 -g 65 -b 64 -d
+    convert $resizeSwitch "${imageFile}-122.bmp" "${imageFile}.${imageExtension}"
+    rm "${imageFile}-122.bmp"
+else
+    echo "[DEBUG] Meteor Decoding failed, either a bad pass/low SNR or a software problem"
+fi
+
+if [ "${removeAudio}" -ne "" ]; then
+    rm $normalisedAudioFile
+    rm $demodulatedAudioFile
+fi

--- a/modules/meteor-m2/meteor_process.sh
+++ b/modules/meteor-m2/meteor_process.sh
@@ -43,3 +43,7 @@ if [ "${removeFiles}" -ne "" ]; then
     rm $normalisedAudioFile
     rm $demodulatedAudioFile
 fi
+
+# Remove old data
+removeOldData -t $keepDataForDays -d rootMeteorImgDir
+removeOldData -t $keepDataForDays -d rootMeteorRecDir

--- a/modules/meteor-m2/meteor_process.sh
+++ b/modules/meteor-m2/meteor_process.sh
@@ -30,7 +30,7 @@ fi
 # Decide the file and make image.
 if [ -f $decodedAudioFile ]; then
     echo "I got a successful ${3}.dec file. Creating false color image"
-    ./medet/medet_arm $decodedAudioFile "${imageFile}-122" -r 66 -g 65 -b 64 -d
+    ./medet/medet_arm $decodedAudioFile "${imageFile}-122" -r 68 -g 65 -b 64 -d
     convert $resizeSwitch "${imageFile}-122.bmp" "${imageFile}.${imageExtension}"
     if [ -f "${imageFile}.${imageExtension}" ]; then
       rm "${imageFile}-122.bmp"
@@ -45,5 +45,5 @@ if [ "${removeFiles}" -ne "" ]; then
 fi
 
 # Remove old data
-removeOldData -t $keepDataForDays -d rootMeteorImgDir
-removeOldData -t $keepDataForDays -d rootMeteorRecDir
+removeOldData -t $keepDataForDays -d $rootMeteorImgDir
+removeOldData -t $keepDataForDays -d $rootMeteorRecDir

--- a/modules/meteor-m2/meteor_process.sh
+++ b/modules/meteor-m2/meteor_process.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 
-processedFile="${recdir}/${3}"
-imageFile="${imgdir}/${3}"
+processedFile="${recdir}/${1}"
+imageFile="${imgdir}/${1}"
 normalisedAudioFile="${processedFile}.wav"
 demodulatedAudioFile="${processedFile}.qpsk"
 decodedAudioFile="${processedFile}.dec"
@@ -18,7 +18,7 @@ echo "Decoding in progress (QPSK to BMP)"
 
 # Get the image file extension
 if [ "$imageExtension" == "" ]; then
-  imageExtension = "jpg"
+  imageExtension="jpg"
 fi
 
 # Should we resize the image?
@@ -30,14 +30,16 @@ fi
 # Decide the file and make image.
 if [ -f $decodedAudioFile ]; then
     echo "I got a successful ${3}.dec file. Creating false color image"
-    ./medet/medet_arm $decodedAudioFile "${iageFile}-122" -r 66 -g 65 -b 64 -d
+    ./medet/medet_arm $decodedAudioFile "${imageFile}-122" -r 66 -g 65 -b 64 -d
     convert $resizeSwitch "${imageFile}-122.bmp" "${imageFile}.${imageExtension}"
-    rm "${imageFile}-122.bmp"
+    if [ -f "${imageFile}.${imageExtension}" ]; then
+      rm "${imageFile}-122.bmp"
+    fi
 else
     echo "[DEBUG] Meteor Decoding failed, either a bad pass/low SNR or a software problem"
 fi
 
-if [ "${removeAudio}" -ne "" ]; then
+if [ "${removeFiles}" -ne "" ]; then
     rm $normalisedAudioFile
     rm $demodulatedAudioFile
 fi

--- a/modules/meteor-m2/meteor_record.sh
+++ b/modules/meteor-m2/meteor_record.sh
@@ -10,13 +10,10 @@ durationMin=$(bc <<< "$duration/60 +2")
 # recording
 #
 echo "$startT-$stopT, duration: $durationMin min"
+
+# TODO: read Meteor configuration file for configuration data to pass on.
 # mlrpt -s $startT-$stopT -t $durationMin -c M2-1-SA7BNT.cfg
 
-# return 0
-
-# I don't have an LNA or similar between my SDR and my antenna, so
-# I don't need the below.
-# BIAS_TEE="enable_bias_tee"
 
 # $1 = Satellite Name
 # $2 = Frequency
@@ -50,28 +47,8 @@ timeout ${6} rtl_fm -f ${2} -M raw -s 288k -g 48 -p 1 | sox -t raw -r 288k -c 2 
 echo "Normalization in progress"
 sox $rawAudioFile $normalisedAudioFile gain -n
 
+# Remove the raw audio file. We don't need it anymore, as we can just
+# use the normalised audio file.
+rm "${recdir}/raw/${3}.wav"
 
-echo "Demodulation in progress (QPSK)"
-meteor_demod -B -o $demodulatedAudioFile $normalisedAudioFile
 
-# if [ "$DELETE_AUDIO" = true ]; then
-#     rm "${recdir}/raw/${3}.wav"
-#     rm "${recdir}/${3}.wav"
-# fi
-
-echo "Decoding in progress (QPSK to BMP)"
-./medet/medet_arm $demodulatedAudioFile $processedFile -cd
-
-# rm "${recdir}/${3}.qpsk"
-
-if [ -f $decodedAudioFile ]; then
-    echo "I got a successful ${3}.dec file. Creating false color image"
-    ./medet/medet_arm $decodedAudioFile "${imgdir}/${3}-122" -r 66 -g 65 -b 64 -d
-    # convert "${imgdir}/${3}-122.bmp" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.jpg"
-    # echo "Rectifying image to adjust aspect ratio"
-    # python3 "${NOAA_HOME}/rectify.py" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.jpg"
-    # rm "${imgdir}/${3}-122.bmp"
-    # rm "${imgdir}/${3}.bmp"
-else
-    echo "[DEBUG] Meteor Decoding failed, either a bad pass/low SNR or a software problem"
-fi

--- a/modules/meteor-m2/meteor_record.sh
+++ b/modules/meteor-m2/meteor_record.sh
@@ -10,4 +10,68 @@ durationMin=$(bc <<< "$duration/60 +2")
 # recording
 #
 echo "$startT-$stopT, duration: $durationMin min"
-mlrpt -s $startT-$stopT -t $durationMin
+# mlrpt -s $startT-$stopT -t $durationMin -c M2-1-SA7BNT.cfg
+
+# return 0
+
+# I don't have an LNA or similar between my SDR and my antenna, so
+# I don't need the below.
+# BIAS_TEE="enable_bias_tee"
+
+# $1 = Satellite Name
+# $2 = Frequency
+# $3 = FileName base
+# $4 = TLE File
+# $5 = EPOC start time
+# $6 = Time to capture
+# $7 = Satellite max elevation
+
+echo "Satellite Name=$1"
+echo "Frequency=$2"
+echo "FileName base=$3"
+echo "TLE File=$4"
+echo "EPOC start time=$5"
+echo "Time to capture=$6"
+echo "Satellite max elevation=$7"
+
+rawDirectory="${recdir}/raw"
+rawAudioFile="${rawDirectory}/${3}.wav"
+processedFile="${recdir}/${3}"
+normalisedAudioFile="${processedFile}.wav"
+demodulatedAudioFile="${processedFile}.qpsk"
+decodedAudioFile="${processedFile}.dec"
+
+# Create folders if they don't exist
+mkdir -p $rawDirectory
+
+echo "Starting rtl_fm record"
+timeout ${6} rtl_fm -f ${2} -M raw -s 288k -g 48 -p 1 | sox -t raw -r 288k -c 2 -b 16 -e s - -t wav $rawAudioFile rate 96k
+
+echo "Normalization in progress"
+sox $rawAudioFile $normalisedAudioFile gain -n
+
+
+echo "Demodulation in progress (QPSK)"
+meteor_demod -B -o $demodulatedAudioFile $normalisedAudioFile
+
+# if [ "$DELETE_AUDIO" = true ]; then
+#     rm "${recdir}/raw/${3}.wav"
+#     rm "${recdir}/${3}.wav"
+# fi
+
+echo "Decoding in progress (QPSK to BMP)"
+./medet/medet_arm $demodulatedAudioFile $processedFile -cd
+
+# rm "${recdir}/${3}.qpsk"
+
+if [ -f $decodedAudioFile ]; then
+    echo "I got a successful ${3}.dec file. Creating false color image"
+    ./medet/medet_arm $decodedAudioFile "${imgdir}/${3}-122" -r 66 -g 65 -b 64 -d
+    # convert "${imgdir}/${3}-122.bmp" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.jpg"
+    # echo "Rectifying image to adjust aspect ratio"
+    # python3 "${NOAA_HOME}/rectify.py" "${NOAA_OUTPUT}/image/${FOLDER_DATE}/${3}-122.jpg"
+    # rm "${imgdir}/${3}-122.bmp"
+    # rm "${imgdir}/${3}.bmp"
+else
+    echo "[DEBUG] Meteor Decoding failed, either a bad pass/low SNR or a software problem"
+fi

--- a/shell_functions.sh
+++ b/shell_functions.sh
@@ -3,3 +3,113 @@
 debugEcho() {
   echo "[DEBUG] $1"
 }
+
+
+function removeFolderFromDirectory() {
+  # This function must have two parameters:
+  #   $1 - the folder name to remove
+  #   $2 - the directory from which to remove $1 from
+  #   $3 - [OPTIONAL] Show messages
+  if [ $# -lt 2 ]; then
+    echo "Illegal number of parameters"
+    return -1
+  fi
+
+  showEcho=""
+
+  while getopts "s" arg; do
+    case $arg in
+      s) showEcho="true";;
+    esac
+  done
+
+  if [ $showEcho ]; then
+    currentDir=$(pwd)
+    debugEcho "From current directory: ${currentDir}"
+    debugEcho "Trying to remove ${1} from ${2}"
+  fi
+
+  # Check that the full path is valid
+  if [ ! -d $2/$1/ ]; then
+    if [ $showEcho ]; then
+      echo "Full path not found: $2/$1/"
+    fi
+    return -1
+  fi
+
+  # Path has been found, therefore remove it.
+  rm -drf $2/$1/
+
+  return 0
+}
+
+removeOldData() {
+  while getopts ":d:t:" arg; do
+    case $arg in
+      d) 
+        directory="${OPTARG}"
+        ;;
+
+      s) 
+        timeDays="${OPTARG}"
+        # Check if $timeDays is not a whole number:
+        re_isanum='^[0-9]+$' # Regex: match whole positive numbers only
+        if ! [[ $timeDays =~ $re_isanum ]] ; 
+        then
+          echo "Error - Invalid timeDays: ${timeDays}"
+          echo "Error - timeDays must be a positive, whole number."
+          return -1
+        fi
+        ;;
+    esac
+  done
+
+  if [[ ! $directory || -d $directory ]];
+  then
+    echo "Error - Invalid directory: ${directory}"
+    return -1
+  fi
+
+  # Remove old data
+  if [ $timeDays -gt 0 ]; then
+    debugEcho "Checking for old removable data from over ${timeDays} days ago."
+    # Check the dates
+    oldDateUnix=$(date --date="$timeDays days ago" +%s)
+
+    oldYear=$(date --date="@$oldDateUnix" +%Y)
+    oldMonth=$(date --date="@$oldDateUnix" +%m)
+    oldDay=$(date --date="@$oldDateUnix" +%d)
+
+    newYear=$(date +%Y)
+    newMonth=$(date +%m)
+    newDay=$(date +%d)
+    
+    debugEcho "Old year: ${oldYear}  New year: ${newYear}"
+    debugEcho "Old month: ${oldMonth}  New month: ${newMonth}"
+    debugEcho "Old day: ${oldDay}  New day: ${newDay}"
+
+    # Remove data
+    monthCounter=1
+    while [ $monthCounter -lt $oldMonth ]
+    do
+      monthCounterAsString=$(printf "%02d" $monthCounter)
+      dayCounter=1
+      while [ $dayCounter -lt $oldDay ]
+      do
+        dayCounterAsString=$(printf "%02d" $dayCounter)
+        removeFolderFromDirectory $dayCounterAsString $directory/$oldYear/$oldMonth
+        (( dayCounter++ ))
+      done
+      removeFolderFromDirectory $monthCounterAsString $directory/$oldYear
+      (( monthCounter++ ))
+    done
+
+    if [ $oldYear -lt $newYear ]; then
+      # The old year is different than the new year (ie old year is the previous year). Therefore,
+      # just remove the entire directory.
+      removeFolderFromDirectory $oldYear $directory
+    fi
+  else
+    debugEcho "[timeDays] set to ${timeDays}. Removing nothing."
+  fi
+}

--- a/shell_functions.sh
+++ b/shell_functions.sh
@@ -44,14 +44,16 @@ function removeFolderFromDirectory() {
 }
 
 removeOldData() {
+  # https://stackoverflow.com/a/16655341
+  local OPTIND directory timeDays arg
   while getopts ":d:t:" arg; do
     case $arg in
       d) 
         directory="${OPTARG}"
         ;;
 
-      s) 
-        timeDays="${OPTARG}"
+      t) 
+        timeDays=$OPTARG
         # Check if $timeDays is not a whole number:
         re_isanum='^[0-9]+$' # Regex: match whole positive numbers only
         if ! [[ $timeDays =~ $re_isanum ]] ; 
@@ -63,8 +65,9 @@ removeOldData() {
         ;;
     esac
   done
+  shift $((OPTIND-1))
 
-  if [[ ! $directory || -d $directory ]];
+  if [[ ! $directory || ! -d $directory ]];
   then
     echo "Error - Invalid directory: ${directory}"
     return -1


### PR DESCRIPTION
This PR removes the use of MLRPT and instead makes use of the [Meteor Decoder](https://github.com/artlav/meteor_decoder) and [Meteor Demodulator](https://github.com/dbdexter-dev/meteor_demod).

**The Problem**

Running MLRPT with the current script on the Raspberry Pi 3 results in severe black blocks in the decoded Meteor image:
<img src="https://user-images.githubusercontent.com/42772107/89729896-d6c97100-da31-11ea-8721-cd5752a77d2c.jpg" height="200px"/>

I can't find the link anymore, but in the depths of somewhere on the internet, someone suggested the black blocks were actually caused by the receiver's lack of power.

**Solution**

The suggestion to replace MLRPT came from [here](https://www.reddit.com/r/RTLSDR/comments/8xlhrq/can_anyone_help_decoding_my_meteor_m2_recording/). Apparently, MLRPT can decode Meteor signals, but it is not the best option. I found that the decoder and demodulator mentioned worked very well on the Raspberry Pi. This suggests MLRPT is way to process-heavy for the Raspberry Pi, whereas the decoder and demodulator are less process-intensive (this is speculation and I cannot prove this).

Following on from using the decoder and demodulator separately, the decoded images turned out much better:
<img src="https://user-images.githubusercontent.com/42772107/90793076-2e55bf80-e303-11ea-8429-3c97235b2a97.png" width="200px"/>